### PR TITLE
Upgrade to Spring Boot 3

### DIFF
--- a/m1-lesson6/pom.xml
+++ b/m1-lesson6/pom.xml
@@ -1,9 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <description>The &quot;Learn Spring Security&quot; Course
-Module  1 - Lesson 6</description>
-    
+    <description>The &quot;Learn Spring Security&quot; Course Module 1 - Lesson 6</description>
 
     <groupId>com.baeldung.m1</groupId>
     <artifactId>learn-spring-security-m1-l6</artifactId>
@@ -13,65 +11,36 @@ Module  1 - Lesson 6</description>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.2.RELEASE</version>
+        <version>3.0.5</version>
         <relativePath></relativePath> <!-- lookup parent from repository -->
     </parent>
 
     <dependencies>
-
         <!-- web -->
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-tomcat</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-jasper</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>nz.net.ultraq.thymeleaf</groupId>
+            <artifactId>thymeleaf-layout-dialect</artifactId>
+            <version>3.2.1</version>
+        </dependency>
         <!-- security -->
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
-
-        <!-- marshalling -->
-
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <!-- common utilities -->
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
         <!-- logging -->
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -92,52 +61,25 @@ Module  1 - Lesson 6</description>
         </dependency>
 
         <!-- test scoped -->
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-        </dependency>        
-
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -145,30 +87,13 @@ Module  1 - Lesson 6</description>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 
-   <properties>
-
+    <properties>
         <!-- non-dependencies -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
-        
-        <!-- commons and utils -->
-        <commons-lang3.version>3.5</commons-lang3.version>
-        <guava.version>21.0</guava.version>
-        
-        <!-- persistence -->       
-        <validation-api.version>1.1.0.Final</validation-api.version>
-  
-        <rest-assured.version>2.9.0</rest-assured.version>
-
-        <!-- maven plugins -->
-		<maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
-		<maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
-		<maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>		
-
+        <java.version>17</java.version>
     </properties>
 
     <developers>
@@ -179,5 +104,4 @@ Module  1 - Lesson 6</description>
             <id>eugenp</id>
         </developer>
     </developers>
-
 </project>

--- a/m1-lesson6/src/main/java/com/baeldung/lss/spring/LssApp6.java
+++ b/m1-lesson6/src/main/java/com/baeldung/lss/spring/LssApp6.java
@@ -1,24 +1,22 @@
 package com.baeldung.lss.spring;
 
+import com.baeldung.lss.persistence.InMemoryUserRepository;
+import com.baeldung.lss.persistence.UserRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 
-import com.baeldung.lss.persistence.InMemoryUserRepository;
-import com.baeldung.lss.persistence.UserRepository;
-
 @SpringBootApplication
 @ComponentScan("com.baeldung.lss.web")
-public class LssApp6 { 
-    
+public class LssApp6 {
+
     @Bean
     public UserRepository userRepository() {
         return new InMemoryUserRepository();
     }
 
     public static void main(String[] args) throws Exception {
-        SpringApplication.run(new Class[] { LssApp6.class, LssSecurityConfig.class, LssWebMvcConfiguration.class }, args);
+        SpringApplication.run(new Class[]{LssApp6.class, LssSecurityConfig.class, LssWebMvcConfiguration.class}, args);
     }
-
 }

--- a/m1-lesson6/src/main/java/com/baeldung/lss/spring/LssSecurityConfig.java
+++ b/m1-lesson6/src/main/java/com/baeldung/lss/spring/LssSecurityConfig.java
@@ -1,45 +1,36 @@
 package com.baeldung.lss.spring;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
-@EnableWebSecurity
-public class LssSecurityConfig extends WebSecurityConfigurerAdapter {
+public class LssSecurityConfig {
 
-    public LssSecurityConfig() {
-        super();
+    @Bean
+    public InMemoryUserDetailsManager configureGlobal() {
+        UserDetails user = User.withDefaultPasswordEncoder()
+                .username("user")
+                .password("pass")
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
     }
 
-    //
-
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception { // @formatter:off 
-        auth.
-            inMemoryAuthentication().
-            withUser("user").password("pass").
-            roles("USER");
-    } // @formatter:on
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception { // @formatter:off
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-        .authorizeRequests()
+                .authorizeHttpRequests()
                 .anyRequest().authenticated()
-        
-        .and()
-        .formLogin().
-            loginPage("/login").permitAll().
-            loginProcessingUrl("/doLogin")
-
-        .and()
-        .logout().permitAll().logoutUrl("/doLogout")
-        
-        .and()
-        .csrf().disable()
-        ;
+                .and()
+                .formLogin()
+                .loginPage("/login").permitAll()
+                .loginProcessingUrl("/doLogin")
+                .and()
+                .logout().permitAll().logoutUrl("/doLogout")
+                .and().csrf().disable();
+        return http.build();
     }
-
 }

--- a/m1-lesson6/src/main/java/com/baeldung/lss/spring/LssWebMvcConfiguration.java
+++ b/m1-lesson6/src/main/java/com/baeldung/lss/spring/LssWebMvcConfiguration.java
@@ -1,5 +1,7 @@
 package com.baeldung.lss.spring;
 
+import com.baeldung.lss.persistence.UserRepository;
+import com.baeldung.lss.web.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -7,34 +9,28 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-
-import com.baeldung.lss.persistence.UserRepository;
-import com.baeldung.lss.web.model.User;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @EnableWebMvc
 @Configuration
-public class LssWebMvcConfiguration extends WebMvcConfigurerAdapter {
-    
+public class LssWebMvcConfiguration implements WebMvcConfigurer {
+
     @Autowired
     private UserRepository userRepository;
 
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addViewController("/login").setViewName("loginPage");
-
         registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
-    }       
-    
+    }
+
     @Override
     public void addFormatters(FormatterRegistry registry) {
-        registry.addConverter(new  Converter<String, User>() {
+        registry.addConverter(new Converter<String, User>() {
             @Override
             public User convert(String id) {
                 return userRepository.findUser(Long.valueOf(id));
             }
         });
-       
     }
-
 }

--- a/m1-lesson6/src/main/java/com/baeldung/lss/web/controller/UserController.java
+++ b/m1-lesson6/src/main/java/com/baeldung/lss/web/controller/UserController.java
@@ -6,10 +6,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
@@ -24,18 +21,18 @@ public class UserController {
         this.userRepository = userRepository;
     }
 
-    @RequestMapping
+    @GetMapping
     public ModelAndView list() {
         Iterable<User> users = this.userRepository.findAll();
         return new ModelAndView("tl/list", "users", users);
     }
 
-    @RequestMapping("{id}")
+    @GetMapping("/{id}")
     public ModelAndView view(@PathVariable("id") User user) {
         return new ModelAndView("tl/view", "user", user);
     }
 
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping
     public ModelAndView create(@Valid User user, BindingResult result, RedirectAttributes redirect) {
         if (result.hasErrors()) {
             return new ModelAndView("tl/form", "formErrors", result.getAllErrors());
@@ -45,19 +42,19 @@ public class UserController {
         return new ModelAndView("redirect:/user/{user.id}", "user.id", user.getId());
     }
 
-    @RequestMapping(value = "delete/{id}")
+    @GetMapping(value = "/delete/{id}")
     public ModelAndView delete(@PathVariable("id") Long id) {
         this.userRepository.deleteUser(id);
-        return new ModelAndView("redirect:/user/");
+        return new ModelAndView("redirect:/user");
     }
 
-    @RequestMapping(value = "modify/{id}", method = RequestMethod.GET)
+    @GetMapping(value = "/modify/{id}")
     public ModelAndView modifyForm(@PathVariable("id") User user) {
         return new ModelAndView("tl/form", "user", user);
     }
 
     // the form
-    @RequestMapping(params = "form", method = RequestMethod.GET)
+    @GetMapping(params = "form")
     public String createForm(@ModelAttribute User user) {
         return "tl/form";
     }

--- a/m1-lesson6/src/main/java/com/baeldung/lss/web/controller/UserController.java
+++ b/m1-lesson6/src/main/java/com/baeldung/lss/web/controller/UserController.java
@@ -1,7 +1,8 @@
 package com.baeldung.lss.web.controller;
 
-import javax.validation.Valid;
-
+import com.baeldung.lss.persistence.UserRepository;
+import com.baeldung.lss.web.model.User;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
@@ -11,9 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
-import com.baeldung.lss.persistence.UserRepository;
-import com.baeldung.lss.web.model.User;
 
 @Controller
 @RequestMapping("/user")
@@ -25,8 +23,6 @@ public class UserController {
     public UserController(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
-
-    //
 
     @RequestMapping
     public ModelAndView list() {
@@ -61,7 +57,6 @@ public class UserController {
     }
 
     // the form
-
     @RequestMapping(params = "form", method = RequestMethod.GET)
     public String createForm(@ModelAttribute User user) {
         return "tl/form";

--- a/m1-lesson6/src/main/java/com/baeldung/lss/web/model/User.java
+++ b/m1-lesson6/src/main/java/com/baeldung/lss/web/model/User.java
@@ -1,17 +1,16 @@
 package com.baeldung.lss.web.model;
 
 import java.util.Calendar;
-
-import org.hibernate.validator.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 
 public class User {
 
     private Long id;
 
-    @NotEmpty(message = "Username is required.")
+    @NotBlank(message = "Username is required.")
     private String username;
 
-    @NotEmpty(message = "Email is required.")
+    @NotBlank(message = "Email is required.")
     private String email;
 
     private Calendar created = Calendar.getInstance();

--- a/m1-lesson6/src/main/resources/templates/tl/form.html
+++ b/m1-lesson6/src/main/resources/templates/tl/form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout" layout:decorate="~{layout}">
 <head>
 <title>Users : Create</title>
 </head>

--- a/m1-lesson6/src/main/resources/templates/tl/form.html
+++ b/m1-lesson6/src/main/resources/templates/tl/form.html
@@ -6,7 +6,7 @@
 <body>
     <h1 layout:fragment="header">Users : Create</h1>
     <div layout:fragment="content" class="container">
-        <form id="userForm" th:action="@{/user/(form)}" th:object="${user}" action="#" method="post">
+        <form id="userForm" th:action="@{/user(form)}" th:object="${user}" action="#" method="post">
             <div th:if="${#fields.hasErrors('*')}" class="alert alert-error">
                 <p th:each="error : ${#fields.errors('*')}" th:text="${error}">Validation error</p>
             </div>

--- a/m1-lesson6/src/main/resources/templates/tl/list.html
+++ b/m1-lesson6/src/main/resources/templates/tl/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout" layout:decorate="~{layout}">
 <head>
 <title>Users : View all</title>
 </head>

--- a/m1-lesson6/src/main/resources/templates/tl/list.html
+++ b/m1-lesson6/src/main/resources/templates/tl/list.html
@@ -7,7 +7,7 @@
     <h1 layout:fragment="header">Users : View all</h1>
     <div layout:fragment="content" class="container">
         <div class="pull-right">
-            <a href="form.html" th:href="@{/user/(form)}">Create User</a>
+            <a href="form.html" th:href="@{/user(form)}">Create User</a>
         </div>
         <table class="table table-bordered table-striped">
             <thead>

--- a/m1-lesson6/src/main/resources/templates/tl/view.html
+++ b/m1-lesson6/src/main/resources/templates/tl/view.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout" layout:decorate="~{layout}">
 <head>
 <title>Users : View</title>
 </head>

--- a/m1-lesson6/src/test/java/com/baeldung/test/Lss6IntegrationTest.java
+++ b/m1-lesson6/src/test/java/com/baeldung/test/Lss6IntegrationTest.java
@@ -1,14 +1,13 @@
 package com.baeldung.test;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import com.baeldung.lss.spring.LssApp6;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.baeldung.lss.spring.LssApp6;
-
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = LssApp6.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class Lss6IntegrationTest {
 


### PR DESCRIPTION
- Java version upgraded to JDK 17
- Spring Boot upgraded to version 3.0.5
- Added `nz.net.ultraq.thymeleaf` as it's no longer `thymeleaf` dependency. It's needed for layout
- Replaced `javax`  `@Valid` and `hibernate`  `@NotEmpty` validator with Jakarta validator shipped with `spring-boot-starter-validation`
- Removed `spring-boot-starter-tomcat`, `tomcat-embed-jasper`, `jstl`, `guava`, `commons-lang3`, `hamcrest-core`, `hamcrest-library`, `mockito-core` dependencies as they are not used in the project
- Removed `jackson-databind` since it's provided as a transitive dependency by Spring Boot
- Replaced `spring-test` with `spring-boot-starter-test` to follow latest standards
- Used JUnit 5 instead of JUnit 4
- Replaced `@NotEmpty` with Jakarta `@NotBlank` as the Hibernate one is deprecated
- Used component based configurations for security as `WebSecurityConfigurerAdapter` is deprecated. More info: https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter
- Replaced `WebMvcConfigurerAdapter` with `WebMvcConfigurer` as it's deprecated
- Replaced `@RequestMapping` on controller method with appropriate `@GetMapping`, `@PostMapping`, ... to follow latest standards. Also unified trailing slash as it's deprecated in the latest version of Spring Boot. More info: https://github.com/spring-projects/spring-framework/issues/28552
- Also removed trailing slash from `th:href="@{/user(form)}"` on templates
- Changed `layout:decorator="layout"` on templates with `layout:decorate="~{layout}"` to follow latest Thymleaf 3 syntax and render the page correctly
- Updated the test to use JUnit 5 annotations